### PR TITLE
added explore option

### DIFF
--- a/algotom/algotom.py
+++ b/algotom/algotom.py
@@ -1,0 +1,109 @@
+# ===========================================================================
+# ===========================================================================
+# Copyright (c) 2021 Nghia T. Vo. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ===========================================================================
+# Author: Nghia T. Vo
+# E-mail: algotomography@gmail.com
+# Description: Examples of how to use the Algotom package.
+# ===========================================================================
+
+"""
+The following example shows how to use Algotom to explore a tomographic data
+in the hdf/nxs format.
+
+Raw data is at: https://zenodo.org/record/1443568
+There're two files: "pco1-68067.hdf" contains flat-field, dark-field, and
+projection images; "68067.nxs" contains metadata with a link to the
+"pco1-68067.hdf" file.
+
+To load a dataset from a hdf/nxs file, one needs to know the key path. This
+can be done using the Hdfview software or using Algotom functions as below.
+"""
+
+import numpy as np
+import algotom.io.converter as conv
+import algotom.io.loadersaver as losa
+
+from algotom.util import log
+
+
+def explore(args):
+    # The following function returns a full list of key-paths, data-shapes,
+    # and data-types to datasets in the hdf/nxs file.
+    log.info("1 -> Print list of keys to datasets: ")
+    keys, shapes, dtypes = losa.get_hdf_information(args.file_path)
+    for i, key in enumerate(keys):
+        log.info("Key :-> {0} | Shape :-> {1} | Type :-> {2}".format(
+            key, shapes[i], dtypes[i]))
+
+
+    # The following function returns a list of key-paths having a pattern,
+    # e.g "rotation", in the keys. Note that in this data there are lots
+    # of soft links pointing to the same dataset.
+    log.info("2 -> Find keys having the key-word 'rotation': ")
+    angle_key, _, _ = losa.find_hdf_key(args.file_path, "rotation")
+    for key in angle_key:
+        log.info("Key having the 'rotation' pattern :-> {0}".format(key))
+
+
+    # For tomographic reconstruction, we need key-paths to dark-field images,
+    # flat-field images, projection images, and rotation-angles. In this data
+    # (collected at the I12 beamline, Diamond Light Source), all images were
+    # recorded into a single 3D array. To indicate the type of an image, they
+    # use a metadata named "image_key":
+    # image_key = 2 <-> a dark-field image
+    # image_key = 1 <-> a flat-field image
+    # image_key = 0 <-> a projection image
+    # Using the following commands we'll get the keys for loading the only
+    # necessary datasets.
+    list_key, list_shape, _ = losa.find_hdf_key(args.file_path, "data")
+    for i, key in enumerate(list_key):
+        # There're datasets with keys containing "data", we only choose a 3D array.
+        if len(list_shape[i])==3:
+            data_key = key
+            break
+    image_key = losa.find_hdf_key(args.file_path, "image_key")[0][0]
+    # Results are:
+    # data_key = "/entry1/flyScanDetector/data"
+    # image_key = "/entry1/flyScanDetector/image_key"
+
+    # Load flat-field images, average them, and save the result as a tif image.
+    log.info("3 -> Load flat-field images, average them, and save the result: ")
+    data = losa.load_hdf(args.file_path, data_key) # This is an object. No data are loaded to the memory yet.
+    ikey = np.asarray(losa.load_hdf(args.file_path, image_key))
+    flat_field = np.mean(np.asarray(data[np.squeeze(np.where(ikey==1.0)), :,:]), axis=0)
+    losa.save_image(args.output_base + "/flat/flat_field.tif", flat_field)
+
+    # Load few projection images and save them as tifs.
+    log.info("4 -> Load projection images in a step of 250 and save to tiff: ")
+    proj_idx = np.squeeze(np.where(ikey == 0))
+    for i in range(0, len(proj_idx), 250):
+        mat = data[proj_idx[i], :, :]
+        name = "0000" + str(proj_idx[i])
+        losa.save_image(args.output_base + "/projection/img_" + name[-5:] + ".tif", mat)
+
+    log.info("5 -> Same as 2 but using a built-in function: ")
+    # The above example can be done using the "converter" module as follows:
+    conv.extract_tif_from_hdf(args.file_path, args.output_base + "/projection2/",
+                              key_path=data_key, index=(proj_idx[0],proj_idx[-1],250), axis=0)
+
+    # We also can convert a folder of tif images to a hdf file.
+    # We use the output of the above example as an input of the following example.
+    log.info("6 -> Convert a list of tiffs to a hdf file: ")
+    angles = np.asarray(losa.load_hdf(args.file_path, angle_key[0]))
+    metadata = {"entry/angle": angles[proj_idx[0]:proj_idx[-1]:250]}
+    conv.convert_tif_to_hdf(args.output_base + "/projection2/", args.output_base + "/hdf/converted.hdf",
+                             key_path="entry/data", option = metadata)
+    log.info("!!! Done !!!")

--- a/algotom/util/config.py
+++ b/algotom/util/config.py
@@ -5,8 +5,11 @@ import argparse
 import configparser
 import numpy as np
 from collections import OrderedDict
+from pathlib import Path
+
 from algotom.util import log
 
+LOGS_HOME = Path.home()/'logs'
 CONFIG_FILE_NAME = os.path.join(str(pathlib.Path.home()), 'algotom.conf')
 
 SECTIONS = OrderedDict()
@@ -16,6 +19,11 @@ SECTIONS['general'] = {
         'default': CONFIG_FILE_NAME,
         'type': str,
         'help': "File name of configuration",
+        'metavar': 'FILE'},
+    'logs-home': {
+        'default': LOGS_HOME,
+        'type': str,
+        'help': "Log file directory",
         'metavar': 'FILE'},
     'verbose': {
         'default': True,
@@ -177,7 +185,7 @@ def show_config(args):
     """
     args = args.__dict__
 
-    log.warning('PV status start')
+    log.warning('algotom status start')
     for section, name in zip(SECTIONS, NICE_NAMES):
         entries = sorted((k for k in args.keys() if k.replace('_', '-') in SECTIONS[section]))
         if entries:
@@ -185,5 +193,5 @@ def show_config(args):
                 value = args[entry] if args[entry] != None else "-"
                 log.info("  {:<16} {}".format(entry, value))
 
-    log.warning('PV status end')
+    log.warning('algotom status end')
  

--- a/bin/algotomcli.py
+++ b/bin/algotomcli.py
@@ -37,17 +37,7 @@ def explore(args):
 
 
 def main():
-    home = os.path.expanduser("~")
-    logs_home = home + '/logs/'
-
-    # make sure logs directory exists
-    if not os.path.exists(logs_home):
-        os.makedirs(logs_home)
-
-    lfname = logs_home + 'pv_' + datetime.strftime(datetime.now(), "%Y-%m-%d_%H:%M:%S") + '.log'
-    log.setup_custom_logger(lfname)
-    log.warning('Logs are saved at: %s' % lfname)
-    
+   
     parser = argparse.ArgumentParser()
     parser.add_argument('--config', **config.SECTIONS['general']['config'])
     explore_params   = config.EXPLORE_PARAMS
@@ -67,8 +57,20 @@ def main():
         cmd_parser.set_defaults(_func=func)
 
     args = config.parse_known_args(parser, subparser=True)
-    args.lfname = lfname
-    
+
+    # create logger
+    logs_home = args.logs_home
+
+    # make sure logs directory exists
+    if not os.path.exists(logs_home):
+        os.makedirs(logs_home)
+
+    lfname = os.path.join(logs_home, 'tomopy_' + datetime.strftime(datetime.now(), "%Y-%m-%d_%H_%M_%S") + '.log')
+
+    log.setup_custom_logger(lfname)
+    log.debug("Started algotom")
+    log.info("Saving log at %s" % lfname)
+     
     try: 
         # load args from default (config.py) if not changed
         config.log_values(args)

--- a/bin/algotomcli.py
+++ b/bin/algotomcli.py
@@ -17,6 +17,7 @@ from datetime import datetime
 
 from algotom.util import log
 from algotom.util import config
+from algotom import algotom
 
 import numpy as np
 import algotom.io.converter as conv
@@ -31,10 +32,10 @@ def init(args):
 def status(args):
     config.show_config(args)
 
-def explore(args):
+def run_explore(args):
     log.info('file path : %s' % args.file_path)
     log.info('output base : %s' % args.output_base)
-
+    algotom.explore(args)
 
 def main():
    
@@ -43,9 +44,9 @@ def main():
     explore_params   = config.EXPLORE_PARAMS
 
     cmd_parsers = [
-        ('init',        init,           (),                              "Create configuration file"),
-        ('status',      status,         explore_params,                  "Show the algotom-cli status"),
-        ('explore',     explore,        explore_params,                  "Explore a tomographic data in the hdf/nxs format"),
+        ('init',        init,               (),                              "Create configuration file"),
+        ('status',      status,             explore_params,                  "Show the algotom-cli status"),
+        ('explore',     run_explore,        explore_params,                  "Explore a tomographic data in the hdf/nxs format"),
     ]
 
     subparsers = parser.add_subparsers(title="Commands", metavar='')


### PR DESCRIPTION
This pull request enables:

```
algotom explore  --file-path ~/Downloads/data/68067.nxs --output-base ~/Downloads
```
but there is an error as if the nxs file has an hardcoded path to the raw data

```
KeyError: "Unable to open object (unable to open external file, external link file name = '/dls/i12/data/2017/cm16771-2/rawdata/pco1-68067.hdf')"
```
@nghia-vo may you check on your system?

Below is the full message:

```
2021-06-16 13:41:14,720 - Started algotom
2021-06-16 13:41:14,720 - Saving log at /Users/decarlo/logs/tomopy_2021-06-16_13_41_14.log
2021-06-16 13:41:14,720 - General
2021-06-16 13:41:14,720 -   config           /Users/decarlo/algotom.conf
2021-06-16 13:41:14,720 -   verbose          True
2021-06-16 13:41:14,720 - file path : /Users/decarlo/Downloads/data/68067.nxs
2021-06-16 13:41:14,720 - output base : /Users/decarlo/Downloads
2021-06-16 13:41:14,721 - 1 -> Print list of keys to datasets: 
Traceback (most recent call last):
  File "/Users/decarlo/opt/anaconda3/bin/algotom", line 33, in <module>
    sys.exit(load_entry_point('algotom==1.0.3', 'console_scripts', 'algotom')())
  File "/Users/decarlo/opt/anaconda3/lib/python3.8/site-packages/algotom-1.0.3-py3.8.egg/EGG-INFO/scripts/algotomcli.py", line 78, in main
  File "/Users/decarlo/opt/anaconda3/lib/python3.8/site-packages/algotom-1.0.3-py3.8.egg/EGG-INFO/scripts/algotomcli.py", line 38, in run_explore
  File "/Users/decarlo/opt/anaconda3/lib/python3.8/site-packages/algotom-1.0.3-py3.8.egg/algotom/algotom.py", line 46, in explore
  File "/Users/decarlo/opt/anaconda3/lib/python3.8/site-packages/algotom-1.0.3-py3.8.egg/algotom/io/loadersaver.py", line 101, in get_hdf_information
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "/Users/decarlo/opt/anaconda3/lib/python3.8/site-packages/h5py/_hl/group.py", line 264, in __getitem__
    oid = h5o.open(self.id, self._e(name), lapl=self._lapl)
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5o.pyx", line 190, in h5py.h5o.open
KeyError: "Unable to open object (unable to open external file, external link file name = '/dls/i12/data/2017/cm16771-2/rawdata/pco1-68067.hdf')"
```