### PR TITLE
Fix convert_sinogram_360_to_180, stitch_image, join_image

### DIFF
--- a/algotom/prep/conversion.py
+++ b/algotom/prep/conversion.py
@@ -432,10 +432,10 @@ def extend_sinogram(sino_360, cor, apply_log=True):
         (overlap, side) = cor
     else:
         if cor <= xcenter:
-            overlap = 2 * (cor + 1)
+            overlap = 2.0 * cor + 1.0
             side = 0
         else:
-            overlap = 2 * (ncol - cor - 1)
+            overlap = 2.0 * (ncol - cor) - 1.0
             side = 1
     overlap_int = int(np.floor(overlap))
     sub_pixel = overlap - overlap_int

--- a/algotom/prep/conversion.py
+++ b/algotom/prep/conversion.py
@@ -109,12 +109,14 @@ def stitch_image(mat1, mat2, overlap, side, wei_mat1=None, wei_mat2=None,
     overlap_int = int(np.floor(overlap))
     sub_pixel = overlap - overlap_int
     if sub_pixel > 0.0:
+        #For proper alignment each part is shifted by half of the sub-pixel overlap so that overlap is reduced to overlap_int
+        sub_pixel_shift = sub_pixel/2.0
         if side == 1:
-            mat1 = shift(mat1, (0, sub_pixel), mode='nearest')
-            mat2 = shift(mat2, (0, -sub_pixel), mode='nearest')
+            mat1 = shift(mat1, (0, sub_pixel_shift), mode='nearest')
+            mat2 = shift(mat2, (0, -sub_pixel_shift), mode='nearest')
         else:
-            mat1 = shift(mat1, (0, -sub_pixel), mode='nearest')
-            mat2 = shift(mat2, (0, sub_pixel), mode='nearest')
+            mat1 = shift(mat1, (0, -sub_pixel_shift), mode='nearest')
+            mat2 = shift(mat2, (0, sub_pixel_shift), mode='nearest')
     if nrow1 != nrow2:
         raise ValueError("Two images are not at the same height!!!")
     if (wei_mat1 is None) or (wei_mat2 is None):
@@ -177,12 +179,14 @@ def join_image(mat1, mat2, joint_width, side, norm=True, total_width=None):
     sub_pixel = joint_width - joint_int
     side = int(side)
     if sub_pixel > 0.0:
+        #For proper alignment each part is shifted by half of the sub-pixel overlap so that overlap is reduced to overlap_int
+        sub_pixel_shift = sub_pixel/2.0
         if side == 1:
-            mat1 = shift(mat1, (0, sub_pixel), mode='nearest')
-            mat2 = shift(mat2, (0, -sub_pixel), mode='nearest')
+            mat1 = shift(mat1, (0, sub_pixel_shift), mode='nearest')
+            mat2 = shift(mat2, (0, -sub_pixel_shift), mode='nearest')
         else:
-            mat1 = shift(mat1, (0, -sub_pixel), mode='nearest')
-            mat2 = shift(mat2, (0, sub_pixel), mode='nearest')
+            mat1 = shift(mat1, (0, -sub_pixel_shift), mode='nearest')
+            mat2 = shift(mat2, (0, sub_pixel_shift), mode='nearest')
     if nrow1 != nrow2:
         raise ValueError("Two images are not at the same height!!!")
     total_width0 = ncol1 + ncol2 + joint_int
@@ -350,11 +354,13 @@ def convert_sinogram_360_to_180(sino_360, cor, wei_mat1=None, wei_mat2=None,
     if isinstance(cor, tuple):
         (overlap, side) = cor
     else:
+        #Imagine detector is continuous and its coordinates go from [-0.5, ncol - 0.5] this way COR=0 is the center of ncol=1 pixel array
+        #Compute two times the distance from the closer edge of the detector to the COR
         if cor <= xcenter:
-            overlap = 2 * (cor + 1)
+            overlap = 2.0 * cor + 1.0
             side = 0
         else:
-            overlap = 2 * (ncol - cor - 1)
+            overlap = 2.0 * (ncol - cor) - 1.0
             side = 1
     sino_stitch = stitch_image(
         sino_top, sino_bot, overlap, side, wei_mat1=wei_mat1,

--- a/tests/test_prep/test_conversion.py
+++ b/tests/test_prep/test_conversion.py
@@ -127,10 +127,10 @@ class ConversionMethods(unittest.TestCase):
     def test_extend_sinogram(self):
         sino_360 = np.pad(self.sino_360[:, 22:], ((0, 0), (0, 22)),
                           mode='constant')
-        sino_ext, _ = conv.extend_sinogram(sino_360, 9.5, apply_log=False)
+        sino_ext, _ = conv.extend_sinogram(sino_360, 10, apply_log=False)
         nrow = sino_ext.shape[0] // 2 + 1
         sino1 = sino_ext[:nrow] + np.fliplr(sino_ext[-nrow:])
-        sino2, _ = conv.convert_sinogram_360_to_180(sino_360, 9.5, norm=False)
+        sino2, _ = conv.convert_sinogram_360_to_180(sino_360, 10, norm=False)
         num = np.max(np.abs(sino1 - sino2))
         self.assertTrue(num < self.eps)
 

--- a/tests/test_prep/test_conversion.py
+++ b/tests/test_prep/test_conversion.py
@@ -111,7 +111,7 @@ class ConversionMethods(unittest.TestCase):
         sino_180 = self.sino_360[0:37]
         sino_360 = np.pad(self.sino_360[:, 22:], ((0, 0), (0, 22)),
                           mode='constant')
-        sino_conv, center = conv.convert_sinogram_360_to_180(sino_360, 9.5)
+        sino_conv, center = conv.convert_sinogram_360_to_180(sino_360, 10.0)
         center = int(np.floor(center))
         radi = self.size // 2
         sino_conv = sino_conv[:, center - radi: center + self.size + 1 - radi]


### PR DESCRIPTION
There were a few bugs regarding subpixel manipulation when calling convert_sinogram_360_to_180

stitch_image, join_image
Two arrays are shifted in the opposite direction by the subpixel shift. To be properly aligned the size of the shift shall be half of the subpixel shift.

convert_sinogram_360_to_180
Fix computation of the overlap, it was half pixel wrong. At least for the detector indexing convention, where left most edge has index -0.5.