### PR TITLE
losa: Fix bug saving files to current working directory

### DIFF
--- a/algotom/io/loadersaver.py
+++ b/algotom/io/loadersaver.py
@@ -248,7 +248,7 @@ def make_folder(file_path):
         Path to a file.
     """
     file_base = os.path.dirname(file_path)
-    if not os.path.exists(file_base):
+    if len(file_base) > 0 and not os.path.exists(file_base):
         try:
             os.makedirs(file_base)
         except FileExistsError:


### PR DESCRIPTION
When saving to the current working directory, `loadersaver.save_image` would throw a makedir error if providing only the output filename:

```python
# implicit current directory -> fails
losa.save_image('fails.tif', img)

# explicit current directory -> works
losa.save_image('./works.tif', img)
```

This updates `loadersaver.make_folder` so that it doesn't attempt to make the base directory if the `file_base` for a given path is empty (i.e. it's assumed to be saved in the current working directory).